### PR TITLE
Allows beforeDeactivateHandler to return promise, adds beforeActivateHandler. Closes #15

### DIFF
--- a/src/RouterApp.js
+++ b/src/RouterApp.js
@@ -1,0 +1,96 @@
+'use strict';
+
+import CancellablePromise from 'metal-promise';
+import {App} from 'senna';
+import {isBoolean, isPromise} from 'metal';
+
+/**
+ * RouterApp class.
+ */
+class RouterApp extends App {
+	/**
+	 * Cancels next navigation with cancellation error.
+	 * @return {!CancellablePromise}
+	 */
+	cancelNext_() {
+		this.pendingNavigate = CancellablePromise.reject(
+			new CancellablePromise.CancellationError('Cancelled by next screen')
+		);
+		return this.pendingNavigate;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	doNavigate_(...args) {
+		let navigateDeferred = this.maybePreventDeactivate_(...args);
+
+		if (!navigateDeferred) {
+			navigateDeferred = this.maybePreventActivate_(...args);
+		}
+
+		if (navigateDeferred) {
+			return navigateDeferred;
+		}
+
+		return super.doNavigate_(...args);
+	}
+
+	/**
+	 * Invokes the next screen's `beforeRouterActivate` method which can
+	 * return either a boolean or a promise that resolves to a boolean which
+	 * can prevent the next navigation.
+	 * @param {!string} path
+	 * @param {*} ...args
+	 * @return {?CancellablePromise}
+	 */
+	maybePreventActivate_(path, ...args) {
+		const route = this.findRoute(path);
+		const nextScreen = this.createScreenInstance(path, route);
+
+		if (nextScreen) {
+			const preventActivate = nextScreen.beforeRouterActivate();
+
+			if (isBoolean(preventActivate) && preventActivate) {
+				return this.cancelNext_();
+			} else if (isPromise(preventActivate)) {
+				return preventActivate.then(prevent => {
+					if (prevent) {
+						return this.cancelNext_();
+					}
+
+					this.pendingNavigate = null;
+					return super.doNavigate_(path, ...args);
+				});
+			}
+		}
+	}
+
+	/**
+	 * Invokes the active screen's `beforeRouterDeactivate` method which can
+	 * return either a boolean or a promise that resolves to a boolean which
+	 * can prevent the next navigation.
+	 * @param {*} ...args
+	 * @return {?CancellablePromise}
+	 */
+	maybePreventDeactivate_(...args) {
+		if (this.activeScreen) {
+			const preventDeactivate = this.activeScreen.beforeRouterDeactivate(); // eslint-disable-line
+
+			if (isBoolean(preventDeactivate) && preventDeactivate) {
+				this.activeScreen.setDeactivate(true);
+			} else if (isPromise(preventDeactivate)) {
+				return preventDeactivate.then(prevent => {
+					if (prevent) {
+						this.activeScreen.setDeactivate(true);
+					}
+
+					this.pendingNavigate = null;
+					return super.doNavigate_(...args);
+				});
+			}
+		}
+	}
+}
+
+export default RouterApp;

--- a/test/Router.js
+++ b/test/Router.js
@@ -839,6 +839,122 @@ describe('Router', function() {
 			});
 	});
 
+	it('should prevent navigation when promise returned by beforeActivateHandler resolves to true', function(done) {
+		router = new Router({
+			beforeActivateHandler: () => {
+				return new CancellablePromise(resolve => {
+					setTimeout(() => {
+						resolve(true);
+					}, 0);
+				});
+			},
+			path: '/path',
+			component: CustomComponent,
+		});
+
+		const {pathname} = window.location;
+
+		Router.router()
+			.navigate('/path')
+			.catch(err => {
+				assert.equal(Router.getActiveComponent(), null);
+				assert.equal(err.message, 'Cancelled by next screen');
+				assert.equal(pathname, window.location.pathname);
+
+				done();
+			});
+	});
+
+	it('should not prevent navigation when promise returned by beforeActivateHandler resolves to false', function(done) {
+		router = new Router({
+			beforeActivateHandler: () => {
+				return new CancellablePromise(resolve => {
+					setTimeout(() => {
+						resolve(false);
+					}, 0);
+				});
+			},
+			path: '/path',
+			component: CustomComponent,
+		});
+
+		Router.router()
+			.navigate('/path')
+			.then(() => {
+				assert.equal('/path', window.location.pathname);
+				assert.ok(Router.getActiveComponent() instanceof CustomComponent);
+
+				done();
+			});
+	});
+
+	it('should prevent navigation when beforeActivateHandler returns true', function(done) {
+		router = new Router({
+			beforeActivateHandler: () => {
+				return true;
+			},
+			path: '/path',
+			component: CustomComponent,
+		});
+
+		const {pathname} = window.location;
+
+		Router.router()
+			.navigate('/path')
+			.catch(err => {
+				assert.equal(Router.getActiveComponent(), null);
+				assert.equal(err.message, 'Cancelled by next screen');
+				assert.equal(pathname, window.location.pathname);
+
+				done();
+			});
+	});
+
+	it('should not prevent navigation when beforeActivateHandler returns false', function(done) {
+		router = new Router({
+			beforeActivateHandler: () => {
+				return false;
+			},
+			path: '/path',
+			component: CustomComponent,
+		});
+
+		Router.router()
+			.navigate('/path')
+			.then(() => {
+				assert.equal('/path', window.location.pathname);
+				assert.ok(Router.getActiveComponent() instanceof CustomComponent);
+
+				done();
+			});
+	});
+
+	it('should prevent navigation if beforeActivateHandler given by name returns "true"', function(done) {
+		class TestComponent extends CustomComponent {
+			static handleActivate() {
+				return true;
+			}
+		}
+
+		router = new Router({
+			beforeActivateHandler: 'handleActivate',
+			path: '/path/1',
+			component: TestComponent,
+		});
+
+		const {pathname} = window.location;
+
+		Router.router()
+			.navigate('/path/1')
+			.catch(err => {
+				assert.equal(Router.getActiveComponent(), null);
+				assert.equal(err.message, 'Cancelled by next screen');
+				assert.equal(pathname, window.location.pathname);
+
+				done();
+			});
+	});
+
 	it('should change router as usual if beforeDeactivateHandler returns nothing', function(done) {
 		router = new Router({
 			beforeDeactivateHandler: () => {},
@@ -950,6 +1066,69 @@ describe('Router', function() {
 
 				assert.throws(() => Router.router().navigate('/path/2'));
 				done();
+			});
+	});
+
+	it('should prevent navigation when promise returned by beforeDeactivateHandler resolves to true', function(done) {
+		router = new Router({
+			path: '/path',
+			component: CustomComponent,
+		});
+		router2 = new Router({
+			beforeDeactivateHandler: () => {
+				return new CancellablePromise(resolve => {
+					setTimeout(() => {
+						resolve(true);
+					}, 0);
+				});
+			},
+			path: '/path/2',
+			component: CustomComponent2,
+		});
+
+		Router.router()
+			.navigate('/path/2')
+			.then(() => {
+				Router.router()
+					.navigate('/path')
+					.catch(err => {
+						assert.equal('/path/2', window.location.pathname);
+						assert.equal(err.message, 'Cancelled by active screen');
+						assert.ok(Router.getActiveComponent() instanceof CustomComponent2);
+
+						done();
+					});
+			});
+	});
+
+	it('should not prevent navigation when promise returned by beforeDeactivateHandler resolves to false', function(done) {
+		router = new Router({
+			path: '/path',
+			component: CustomComponent,
+		});
+		router2 = new Router({
+			beforeDeactivateHandler: () => {
+				return new CancellablePromise(resolve => {
+					setTimeout(() => {
+						resolve(false);
+					}, 0);
+				});
+			},
+			path: '/path/2',
+			component: CustomComponent2,
+		});
+
+		Router.router()
+			.navigate('/path/2')
+			.then(() => {
+				Router.router()
+					.navigate('/path')
+					.then(() => {
+						assert.equal('/path', window.location.pathname);
+						assert.ok(Router.getActiveComponent() instanceof CustomComponent);
+
+						done();
+					});
 			});
 	});
 


### PR DESCRIPTION
Currently `Router` has a `beforeDeactivateHandler` config property, if it returns `true` it will prevent the route from being navigated _from_.

```jsx
<Router 
  path="/path"
  component={Component}
  beforeDeactivateHandler={() => {
    return true;
  }}
/>
```

The change allows the function to return a promise instead.

```jsx
<Router 
  path="/path"
  component={Component}
  beforeDeactivateHandler={() => {
    return new Promise(resolve => {
      resolve(true);
    });
  }}
/>
```

It also adds a new config prop called `beforeActivateHandler`, which behaves the exact same way, except returning `true` will prevent that route from being navigated _to_.

```jsx
<Router 
  path="/path"
  component={Component}
  beforeActivateHandler={() => {
    return new Promise(resolve => {
      resolve(true);
    });
  }}
/>
```

The function can be a method of the router's component. Note that this feature is already present in metal-router.

```jsx
class MyComponent extends Component {
  handleDeactivate() {
    return true;
  }
}

...

<Router 
  path="/path"
  component={Component}
  beforeDeactivateHandler="handleDeactivate"
/>
```

I've added the same functionality to `beforeActivateHandler`, except the method must be `static` because the component will not have been invoked at that point.

```jsx
class MyComponent extends Component {
  static handleActivate() {
    return true;
  }
}

...

<Router 
  path="/path"
  component={Component}
  beforeActivateHandler="handleActivate"
/>
```

In #15 the suggestion is to have functions that prevent the navigation if they return `false`. Since `beforeDeactivateHandler` is already present, and prevents navigation when returning `true`, I left it alone for consistency.